### PR TITLE
Remove unnecessary memset call in secrandom function

### DIFF
--- a/src/secrandom.h
+++ b/src/secrandom.h
@@ -26,7 +26,6 @@
 #include <errno.h>
 #include <limits.h>
 #include <stddef.h>
-#include <string.h> /* memset */
 
 typedef enum secrandom_result_e {
     SECRANDOM_SUCCESS     = 0,
@@ -466,8 +465,6 @@ static inline secrandom_result_e secrandom(void *buf, size_t len,
     }
 #endif /* POSIX */
 
-    /* if all methods failed, zero the buffer */
-    memset(buf, 0, len);
     if (rc == SECRANDOM_UNSUPPORTED) {
         errno = ENOSYS; /* Function not implemented */
     } else {


### PR DESCRIPTION
This pull request makes changes to the `src/secrandom.h` file to improve the handling of unsupported cases in the `secrandom` function and removes redundant code.

Improvements to error handling:

* Removed the `memset` call that zeroed the buffer in the `secrandom` function when all methods failed, simplifying the logic and relying on setting `errno` to indicate an unsupported case.

Code cleanup:

* Removed the inclusion of the `<string.h>` header, as `memset` is no longer used in the file.